### PR TITLE
Tf guide link fix

### DIFF
--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -21,7 +21,7 @@
         "colab_type": "text"
       },
       "source": [
-        " <a href=\"https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb\">\n",
+        "<a href=\"https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb\" target=\"_parent\">\n",
         "<img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n",
         "\n"

--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -90,29 +90,6 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "DUNzJc4jTj6G"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/quickstart/beginner\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/quickstart/beginner.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/quickstart/beginner.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/quickstart/beginner.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
         "id": "04QgGZc9bF5D"
       },
       "source": [
@@ -121,6 +98,19 @@
         "1. Build a neural network that classifies images.\n",
         "2. Train this neural network.\n",
         "3. And, finally, evaluate the accuracy of the model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "hiH7AC-NTniF"
+      },
+      "source": [
+        "This is a [Google Colaboratory](https://colab.research.google.com/notebooks/welcome.ipynb) notebook file. Python programs are run directly in the browser—a great way to learn and use TensorFlow. To follow this tutorial, run the notebook in Google Colab by clicking the button at the top of this page.\n",
+        "\n",
+        "1. In Colab, connect to a Python runtime: At the top-right of the menu bar, select *CONNECT*.\n",
+        "2. Run all the notebook code cells: Select *Runtime* > *Run all*."
       ]
     },
     {

--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -22,7 +22,7 @@
       },
       "source": [
         " <a href=\"https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb\">\n",
-        "  <center><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/> </center>\n",
+        "<img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n",
         "\n"
       ]
@@ -121,19 +121,6 @@
         "1. Build a neural network that classifies images.\n",
         "2. Train this neural network.\n",
         "3. And, finally, evaluate the accuracy of the model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "hiH7AC-NTniF"
-      },
-      "source": [
-        "This is a [Google Colaboratory](https://colab.research.google.com/notebooks/welcome.ipynb) notebook file. Python programs are run directly in the browser—a great way to learn and use TensorFlow. To follow this tutorial, run the notebook in Google Colab by clicking the button at the top of this page.\n",
-        "\n",
-        "1. In Colab, connect to a Python runtime: At the top-right of the menu bar, select *CONNECT*.\n",
-        "2. Run all the notebook code cells: Select *Runtime* > *Run all*."
       ]
     },
     {


### PR DESCRIPTION
- Removes the original TensorFlow Colab links to avoid confusion
- Fixed Colab link as it was showing in Notebook but not in GitHub