### PR TITLE
URL Notice for arangoml.arangodb.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ ArangoML Pipeline is a common and extensible Metadata Layer for Machine Learning
 **News:**
 [ArangoML Pipeline Cloud](https://www.arangodb.com/2020/01/arangoml-pipeline-cloud-manage-machine-learning-metadata/) is offering a no-setup, free-to-try managed service for ArangpML Pipeline.
 
+**NOTICE**
+If you are using the ArangoML Cloud feature and would like to access the ArangoDB WebUI please visit 
+https://a0434a558688.arangodb.cloud:8529/_db/_system/_admin/aardvark/index.html 
+ and sign into the supplied temporary database with the generated username and password.
+
 ## Introduction
 When productizing Machine Learning Pipelines (e.g., [TensorFlow Extended](https://www.tensorflow.org/tfx/guide) or [Kubeflow](https://www.kubeflow.org/))
 the capture (and access to) of metadata across the pipeline is vital. Typically, each of the  components of such ML pipeline produces/requires Metadata, for example:


### PR DESCRIPTION
Adding note with current Oasis URL until redirect is fixed.