### PR TITLE
Link entities api

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started with no installations of any sort (using ArangoML Pipeline Cloud)
 , click :
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_Examples.ipynb) 
 
-The [examples folder](https://github.com/arangoml/arangopipe/tree/master/examples) contains examples for the following:
+The [examples folder](https://github.com/arangoml/arangopipe/tree/master/examples) contains examples that illustrate some features of **Arangopipe** with common machine learning project activities:
 
 1. [Basic workflow](https://github.com/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_Examples.ipynb) of creating a project and tracking machine learning meta-data from project activity.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ To get started with no installations of any sort (using ArangoML Pipeline Cloud)
 , click :
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_Examples.ipynb) 
 
+The [examples folder](https://github.com/arangoml/arangopipe/tree/master/examples) contains examples for the following:
+
+1. [Basic workflow](https://github.com/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_Examples.ipynb) of creating a project and tracking machine learning meta-data from project activity.
+
+2. An example of [connecting](https://github.com/arangoml/arangopipe/blob/master/examples/Reuse_Old_Arangopipe_Connection.ipynb) to the **Arangopipe** database created in the previous step using saved connection information.
+3. An example of using **Arangopipe** to track [covariate shift](https://github.com/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_ext2.ipynb)
+
+4. An example of using **Arangopipe** to document and capture meta-data from machine learning [experiments](https://github.com/arangoml/arangopipe/blob/master/examples/Arangopipe_Feature_Example_ext1.ipynb).
+
+5. An example of [linking](https://github.com/arangoml/arangopipe/blob/master/examples/Data_Summaries.ipynb) metadata from different project activities.
+
 ## Introduction
 When productizing Machine Learning Pipelines (e.g., [TensorFlow Extended](https://www.tensorflow.org/tfx/guide) or [Kubeflow](https://www.kubeflow.org/))
 the capture (and access to) of metadata across the pipeline is vital. Typically, each of the  components of such ML pipeline produces/requires Metadata, for example:
@@ -146,6 +157,8 @@ If you would like to use **Arangopipe** with your pipelines, you would need to d
 
 4. `pip install PyYAML==5.1.1`
 5. `pip install pandas `
+
+
 
 
 ## Arangopipe User Interface Application

--- a/arangopipe/arangopipe/__init__.py
+++ b/arangopipe/arangopipe/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of the arangopipe package
-__version__ = "0.0.6.8.9"
+__version__ = "0.0.6.9.0"

--- a/arangopipe/arangopipe/__init__.py
+++ b/arangopipe/arangopipe/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of the arangopipe package
-__version__ = "0.0.6.9.1"
+__version__ = "0.0.6.9.3"

--- a/arangopipe/arangopipe/__init__.py
+++ b/arangopipe/arangopipe/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of the arangopipe package
-__version__ = "0.0.6.9.0"
+__version__ = "0.0.6.9.1"

--- a/arangopipe/arangopipe/arangopipe_storage/arangopipe_api.py
+++ b/arangopipe/arangopipe/arangopipe_storage/arangopipe_api.py
@@ -62,56 +62,40 @@ class ArangoPipe:
         apc = ArangoPipeConfig()
         return apc.get_cfg()
 
+    def lookup_entity(self, asset_name, asset_type):
+        aql = 'FOR doc IN %s FILTER doc.name == @value RETURN doc' % (
+            asset_type)
+        # Execute the query
+        cursor = self.db.aql.execute(aql, bind_vars={'value': asset_name})
+        asset_keys = [doc for doc in cursor]
+
+        asset_info = None
+        if len(asset_keys) == 0:
+            logger.info("The asset by name: " + asset_name +\
+                         " was not found in Arangopipe!")
+        else:
+            asset_info = asset_keys[0]
+
+        return asset_info
+
     def lookup_dataset(self, dataset_name):
         """ Return a dataset identifier given a name. This can be used to get the dataset id that is used to log run information associated with execution of the pipeline."""
 
-        # Execute the query
-        cursor = self.db.aql.execute(
-            'FOR doc IN datasets FILTER doc.name == @value RETURN doc',
-            bind_vars={'value': dataset_name})
-        dataset_keys = [doc for doc in cursor]
-
-        dataset_info = None
-        if len(dataset_keys) == 0:
-            logger.info("The dataset by name: " + dataset_name +\
-                         " was not found in Arangopipe!")
-        else:
-            dataset_info = dataset_keys[0]
+        dataset_info = self.lookup_entity(dataset_name, 'datasets')
 
         return dataset_info
 
     def lookup_featureset(self, feature_set_name):
         """ Return a featureset identifier given a name. This can be used to get the featureset id that is used to log run information associated with execution of the pipeline."""
 
-        # Execute the query
-        cursor = self.db.aql.execute(
-            'FOR doc IN featuresets FILTER doc.name == @value RETURN doc',
-            bind_vars={'value': feature_set_name})
-        featureset_info = None
-        feature_set_keys = [doc for doc in cursor]
-        if len(feature_set_keys) == 0:
-            logger.info("The featureset by name: " + feature_set_name +\
-                         " was not found in Arangopipe!")
-        else:
-            featureset_info = feature_set_keys[0]
+        featureset_info = self.lookup_entity(feature_set_name, 'featuresets')
 
         return featureset_info
 
     def lookup_model(self, model_name):
         """ Return a model identifier given a name. This can be used to get the model id that is used to log run information associated with execution of the pipeline."""
 
-        # Execute the query
-        cursor = self.db.aql.execute(
-            'FOR doc IN models FILTER doc.name == @value RETURN doc',
-            bind_vars={'value': model_name})
-        model_info = None
-        model_keys = [doc for doc in cursor]
-
-        if len(model_keys) == 0:
-            logger.info("The model by name: " + model_name +\
-                         " was not found in Arangopipe!")
-        else:
-            model_info = model_keys[0]
+        model_info = self.lookup_entity(model_name, 'models')
 
         return model_info
 

--- a/arangopipe/arangopipe/arangopipe_storage/arangopipe_api.py
+++ b/arangopipe/arangopipe/arangopipe_storage/arangopipe_api.py
@@ -73,7 +73,7 @@ class ArangoPipe:
 
         dataset_info = None
         if len(dataset_keys) == 0:
-            logger.error("The dataset by name: " + dataset_name +\
+            logger.info("The dataset by name: " + dataset_name +\
                          " was not found in Arangopipe!")
         else:
             dataset_info = dataset_keys[0]
@@ -90,7 +90,7 @@ class ArangoPipe:
         featureset_info = None
         feature_set_keys = [doc for doc in cursor]
         if len(feature_set_keys) == 0:
-            logger.error("The featureset by name: " + feature_set_name +\
+            logger.info("The featureset by name: " + feature_set_name +\
                          " was not found in Arangopipe!")
         else:
             featureset_info = feature_set_keys[0]
@@ -108,7 +108,7 @@ class ArangoPipe:
         model_keys = [doc for doc in cursor]
 
         if len(model_keys) == 0:
-            logger.error("The model by name: " + model_name +\
+            logger.info("The model by name: " + model_name +\
                          " was not found in Arangopipe!")
         else:
             model_info = model_keys[0]
@@ -128,7 +128,7 @@ class ArangoPipe:
         mp_info = None
         mp_keys = [doc for doc in cursor]
         if len(mp_keys) == 0:
-            logger.error("The model params for tag: " + tag_value +\
+            logger.info("The model params for tag: " + tag_value +\
                          " was not found in Arangopipe!")
         else:
             mp_info = mp_keys[0]
@@ -147,7 +147,7 @@ class ArangoPipe:
         mperf_info = None
         mperf_keys = [doc for doc in cursor]
         if len(mperf_keys) == 0:
-            logger.error("The model performance for tag: " + tag_value +\
+            logger.info("The model performance for tag: " + tag_value +\
                          " was not found in Arangopipe!")
         else:
             mperf_info = mperf_keys[0]
@@ -183,6 +183,18 @@ class ArangoPipe:
     def register_model(self, mi, user_id = "authorized_user",\
                        project = "Wine-Quality-Regression-Modelling"):
         """ Register a model. The operation requires specifying a user id. If the user id is permitted to register a model, then the registration proceeds, otherwise an unauthorized operation is indicated. """
+
+        model_name = mi["name"]
+        try:
+            existing_model = self.lookup_model(model_name)
+        except AQLQueryExecuteError as e:
+            msg = "The model name %s is not taken" % (model_name)
+            logger.info(msg)
+        if existing_model is not None:
+            msg = "It looks like the model name %s is already taken, try another name" % (
+                model_name)
+            logger.error(msg)
+            return None
         models = self.emlg.vertex_collection("models")
         model_reg = models.insert(mi)
 
@@ -206,6 +218,18 @@ class ArangoPipe:
 
     def register_dataset(self, ds_info, user_id="authorized_user"):
         """ Register a dataset. The operation requires specifying a user id. If the user id is permitted to register a dataset, then the registration proceeds, otherwise an unauthorized operation is indicated. """
+
+        ds_name = ds_info["name"]
+        try:
+            existing_ds = self.lookup_dataset(ds_name)
+        except AQLQueryExecuteError as e:
+            msg = "The dataset name %s is not taken" % (ds_name)
+            logger.info(msg)
+        if existing_ds is not None:
+            msg = "It looks like the dataset name %s is already taken, try another name" % (
+                ds_name)
+            logger.error(msg)
+            return None
         ds = self.emlg.vertex_collection("datasets")
         ds_reg = ds.insert(ds_info)
         logger.info("Recording dataset dataset link " + str(ds_reg))
@@ -216,6 +240,18 @@ class ArangoPipe:
     def register_featureset(self, fs_info, dataset_id, \
                             user_id = "authorized_user"):
         """ Register a featureset. ManagedServiceConnParamThe operation requires specifying a user id. If the user id is permitted to register a featureset, then the registration proceeds, otherwise an unauthorized operation is indicated. """
+        fs_name = fs_info["name"]
+        try:
+            existing_fs = self.lookup_featureset(fs_name)
+        except AQLQueryExecuteError as e:
+            msg = "The featureset name %s is not taken" % (fs_name)
+            logger.info(msg)
+        if existing_fs is not None:
+            msg = "It looks like the featureset name %s is already taken, try another name" % (
+                fs_name)
+            logger.error(msg)
+            return None
+
         fs = self.emlg.vertex_collection("featuresets")
         fs_reg = fs.insert(fs_info)
         logger.info("Recording featureset " + str(fs_reg))

--- a/arangopipe/setup.py
+++ b/arangopipe/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="arangopipe",
-    version="0.0.6.8.9",
+    version="0.0.6.9.0",
     description="package for machine learning meta-data management and analysis",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/arangopipe/setup.py
+++ b/arangopipe/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="arangopipe",
-    version="0.0.6.9.1",
+    version="0.0.6.9.3",
     description="package for machine learning meta-data management and analysis",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/arangopipe/setup.py
+++ b/arangopipe/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="arangopipe",
-    version="0.0.6.9.0",
+    version="0.0.6.9.1",
     description="package for machine learning meta-data management and analysis",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/arangopipe/tests/CItests/arangopipe_testcases.py
+++ b/arangopipe/tests/CItests/arangopipe_testcases.py
@@ -221,6 +221,20 @@ class TestArangopipe(unittest.TestCase):
                             'Exception raised while registering dataset')
         self.assertFalse(err_raised)
         return
+    def test_reregister_dataset(self):
+        err_raised = False
+        try:
+            self.register_dataset()
+            self.register_dataset()
+        except:
+            err_raised = True
+            print('-'*60)
+            traceback.print_exc(file=sys.stdout)
+            print('-'*60)
+            self.assertTrue(err_raised,
+                            'Exception raised while registering dataset')
+        self.assertFalse(err_raised)
+        return
 
     def test_lookup_dataset(self):
         err_raised = False
@@ -251,6 +265,22 @@ class TestArangopipe(unittest.TestCase):
                             'Exception raised while registering featureset')
         self.assertFalse(err_raised)
         return
+    
+    def test_reregister_featureset(self):
+        err_raised = False
+        try:
+            self.register_dataset()
+            self.register_featureset()
+            self.register_featureset()
+        except:
+            err_raised = True
+            print('-'*60)
+            traceback.print_exc(file=sys.stdout)
+            print('-'*60)
+            self.assertTrue(err_raised,
+                            'Exception raised while registering featureset')
+        self.assertFalse(err_raised)
+        return
 
     def test_lookup_featureset(self):
         err_raised = False
@@ -271,6 +301,21 @@ class TestArangopipe(unittest.TestCase):
     def test_register_model(self):
         err_raised = False
         try:
+            self.register_model()
+        except:
+            err_raised = True
+            print('-'*60)
+            traceback.print_exc(file=sys.stdout)
+            print('-'*60)
+            self.assertTrue(err_raised,
+                            'Exception raised while registering model')
+        self.assertFalse(err_raised)
+        return
+    
+    def test_reregister_model(self):
+        err_raised = False
+        try:
+            self.register_model()
             self.register_model()
         except:
             err_raised = True

--- a/arangopipe/tests/CItests/arangopipe_testcases.py
+++ b/arangopipe/tests/CItests/arangopipe_testcases.py
@@ -91,6 +91,38 @@ class TestArangopipe(unittest.TestCase):
                       "type": "elastic net regression"}
         model_reg = self.ap.register_model(model_info)
         return
+    
+    def link_models(self):
+
+        model_info1 = {"name": "elastic_net_wine_model1",
+                      "type": "elastic net regression1"}
+        model_reg1 = self.ap.register_model(model_info1)
+        
+        model_info2 = {"name": "elastic_net_wine_model2",
+                      "type": "elastic net regression2"}
+        model_reg2 = self.ap.register_model(model_info2)
+        
+        model_info3 = {"name": "elastic_net_wine_model3",
+                      "type": "elastic net regression3"}
+        model_reg3 = self.ap.register_model(model_info3)
+        
+        self.ap.link_entities(model_reg1['_id'], model_reg2['_id'])
+        updated_model_info = self.ap.lookup_model(model_info1["name"])
+        print("Updated model:")
+        print(updated_model_info)
+        print("Adding another model link")
+        self.ap.link_entities(model_reg1['_id'], model_reg3['_id'])
+        updated_model_info = self.ap.lookup_model(model_info1["name"])
+        print("Updated model:")
+        print(updated_model_info)
+        added_str = updated_model_info['related_models']
+        added_links = added_str.split(",")
+        link_added = len(added_links) == 2
+        self.assertTrue(link_added,
+                            'Exception raised while linking models')
+        
+        
+        return
 
     def lookup_model(self):
 
@@ -359,6 +391,21 @@ class TestArangopipe(unittest.TestCase):
         self.assertFalse(err_raised)
         return
 
+    def test_link_models(self):
+        err_raised = False
+        try:
+            self.link_models()
+ 
+
+        except:
+            err_raised = True
+            print('-'*60)
+            traceback.print_exc(file=sys.stdout)
+            print('-'*60)
+            self.assertTrue(err_raised,
+                            'Exception raised while provisioning deployment')
+        self.assertFalse(err_raised)
+        
     def test_provision_deployment(self):
         err_raised = False
         try:

--- a/examples/Arangopipe_Feature_Example_ext1.ipynb
+++ b/examples/Arangopipe_Feature_Example_ext1.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",

--- a/examples/Arangopipe_Feature_Example_ext1.ipynb
+++ b/examples/Arangopipe_Feature_Example_ext1.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",

--- a/examples/Arangopipe_Feature_Example_ext1.ipynb
+++ b/examples/Arangopipe_Feature_Example_ext1.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",

--- a/examples/Arangopipe_Feature_Examples.ipynb
+++ b/examples/Arangopipe_Feature_Examples.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Arangopipe_Feature_Examples.ipynb
+++ b/examples/Arangopipe_Feature_Examples.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Arangopipe_Feature_Examples.ipynb
+++ b/examples/Arangopipe_Feature_Examples.ipynb
@@ -1,12 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -18,9 +10,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    ""
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -31,15 +21,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -71,7 +61,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "from arangopipe.arangopipe_storage.arangopipe_api import ArangoPipe\n",
@@ -92,9 +84,7 @@
     "ap = ArangoPipe(config = ap_config)\n",
     "proj_info = {\"name\": \"Housing_Price_Estimation_Project\"}\n",
     "proj_reg = admin.register_project(proj_info)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -126,23 +116,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "data_url = \"https://raw.githubusercontent.com/arangoml/arangopipe/arangopipe_examples/examples/data/cal_housing.csv\"\n",
     "df = pd.read_csv(data_url, error_bad_lines=False)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "df.head()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -153,16 +143,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "ds_info = {\"name\" : \"california-housing-dataset\",\\\n",
     "            \"description\": \"This dataset lists median house prices in Califoria. Various house features are provided\",\\\n",
     "           \"source\": \"UCI ML Repository\" }\n",
     "ds_reg = ap.register_dataset(ds_info)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -185,7 +175,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "df[\"medianHouseValue\"] = df[\"medianHouseValue\"].apply(lambda x: np.log(x))\n",
@@ -193,9 +185,7 @@
     "featureset = {k:str(featureset[k]) for k in featureset}\n",
     "featureset[\"name\"] = \"log_transformed_median_house_value\"\n",
     "fs_reg = ap.register_featureset(featureset, ds_reg[\"_key\"]) # note that the dataset and featureset are linked here."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -213,7 +203,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from sklearn.model_selection import train_test_split\n",
     "preds = df.columns.to_list()\n",
@@ -221,9 +213,7 @@
     "X = df[preds].values\n",
     "Y = df['medianHouseValue'].values\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, Y, test_size=0.33, random_state=42)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -241,7 +231,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from sklearn import linear_model\n",
     "from sklearn.metrics import mean_squared_error\n",
@@ -251,9 +243,7 @@
     "test_pred = clf.predict(X_test)\n",
     "train_mse = mean_squared_error(train_pred, y_train)\n",
     "test_mse = mean_squared_error(test_pred, y_test)\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -266,35 +256,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import io\n",
     "import requests\n",
     "url = ('https://raw.githubusercontent.com/arangoml/arangopipe/master/examples/Arangopipe_Feature_Examples.ipynb')\n",
     "nbjson = requests.get(url).text"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "source": [
-    ""
-   ],
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "model_info = {\"name\": \"Lasso Model for Housing Dataset\",  \"task\": \"Regression\", 'notebook': nbjson}\n",
     "model_reg = ap.register_model(model_info, project = \"Housing_Price_Estimation_Project\")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -329,7 +317,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import uuid\n",
     "import datetime\n",
@@ -351,9 +341,7 @@
     "                    \"tag\": \"Housing_Price_Estimation_Project\",\\\n",
     "                    \"project\": \"Housing_Price_Estimation_Project\"}\n",
     "ap.log_run(run_info)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -364,15 +352,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from google.colab import drive\n",
     "drive.mount('/content/drive')\n",
     "fp = '/content/drive/My Drive/saved_arangopipe_config.yaml'\n",
     "mdb_config.export_cfg(fp)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -395,5 +383,13 @@
     "\n"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/Arangopipe_Feature_ext2.ipynb
+++ b/examples/Arangopipe_Feature_ext2.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Arangopipe_Feature_ext2.ipynb
+++ b/examples/Arangopipe_Feature_ext2.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Arangopipe_Feature_ext2.ipynb
+++ b/examples/Arangopipe_Feature_ext2.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Arangopipe_with_Pytorch_Example.ipynb
+++ b/examples/Arangopipe_with_Pytorch_Example.ipynb
@@ -1,12 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -40,17 +32,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "!pip install torch<=1.2.0\n",
     "!pip install torchtext==0.4\n",
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.9\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1\n",
     "%matplotlib inline"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -99,7 +91,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import torch\n",
     "import torchtext\n",
@@ -112,9 +106,7 @@
     "    root='./.data', ngrams=NGRAMS, vocab=None)\n",
     "BATCH_SIZE = 16\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -142,7 +134,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
@@ -162,9 +156,7 @@
     "    def forward(self, text, offsets):\n",
     "        embedded = self.embedding(text, offsets)\n",
     "        return self.fc(embedded)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -192,15 +184,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "VOCAB_SIZE = len(train_dataset.get_vocab())\n",
     "EMBED_DIM = 32\n",
     "NUN_CLASS = len(train_dataset.get_labels())\n",
     "model = TextSentiment(VOCAB_SIZE, EMBED_DIM, NUN_CLASS).to(device)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -236,7 +228,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "def generate_batch(batch):\n",
     "    label = torch.tensor([entry[0] for entry in batch])\n",
@@ -249,9 +243,7 @@
     "    offsets = torch.tensor(offsets[:-1]).cumsum(dim=0)\n",
     "    text = torch.cat(text)\n",
     "    return text, offsets, label"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -279,7 +271,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from torch.utils.data import DataLoader\n",
     "\n",
@@ -318,9 +312,7 @@
     "            acc += (output.argmax(1) == cls).sum().item()\n",
     "\n",
     "    return loss / len(data_), acc / len(data_)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -349,7 +341,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import time\n",
     "from torch.utils.data.dataset import random_split\n",
@@ -377,9 +371,7 @@
     "    print('Epoch: %d' %(epoch + 1), \" | time in %d minutes, %d seconds\" %(mins, secs))\n",
     "    print(f'\\tLoss: {train_loss:.4f}(train)\\t|\\tAcc: {train_acc * 100:.1f}%(train)')\n",
     "    print(f'\\tLoss: {valid_loss:.4f}(valid)\\t|\\tAcc: {valid_acc * 100:.1f}%(valid)')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -393,14 +385,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "print('Checking the results of test dataset...')\n",
     "test_loss, test_acc = test(test_dataset)\n",
     "print(f'\\tLoss: {test_loss:.4f}(test)\\t|\\tAcc: {test_acc * 100:.1f}%(test)')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -418,7 +410,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import re\n",
     "from torchtext.data.utils import ngrams_iterator\n",
@@ -453,9 +447,7 @@
     "model = model.to(\"cpu\")\n",
     "\n",
     "print(\"This is a %s news\" %ag_news_label[predict(ex_text_str, model, vocab, 2)])"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -466,7 +458,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "from arangopipe.arangopipe_storage.arangopipe_api import ArangoPipe\n",
@@ -482,25 +476,25 @@
     "                        msc.DB_CONN_PROTOCOL : 'https'}\n",
     "        \n",
     "mdb_config = mdb_config.create_connection_config(conn_params)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "admin = ArangoPipeAdmin(reuse_connection = False, config = mdb_config)\n",
     "ap_config = admin.get_config()\n",
     "ap = ArangoPipe(config = ap_config)\n",
     "# Error indicating \"heart beat check was not found\" is expected."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "proj_info = {\"name\": \"Text_Classification_Using_Pytorch\"}\n",
     "proj_reg = admin.register_project(proj_info)\n",
@@ -516,13 +510,13 @@
     "model_info = {\"name\": \"Neural Network\",\\\n",
     "              \"type\": \"Neural network with a linear layer and an embedding layer using the Cross-Entropy loss with SGD optimizer  \"}\n",
     "model_reg = ap.register_model(model_info, project = \"Text_Classification_Using_Pytorch\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "import uuid #used as run id\n",
@@ -547,9 +541,7 @@
     "              \"project\": \"Text_Classification_Using_Pytorch\"}\n",
     "\n",
     "ap.log_run(run_info)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -567,14 +559,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "admin = ArangoPipeAdmin(reuse_connection = True)\n",
     "ap_config = admin.get_config()\n",
     "ap = ArangoPipe(config = ap_config)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -585,12 +577,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "ap.lookup_modelperf(tag_value='text_classification_model_params_saved')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/Arangopipe_with_Pytorch_Example.ipynb
+++ b/examples/Arangopipe_with_Pytorch_Example.ipynb
@@ -39,7 +39,7 @@
     "!pip install torch<=1.2.0\n",
     "!pip install torchtext==0.4\n",
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1\n",
     "%matplotlib inline"
    ]

--- a/examples/Arangopipe_with_Pytorch_Example.ipynb
+++ b/examples/Arangopipe_with_Pytorch_Example.ipynb
@@ -39,7 +39,7 @@
     "!pip install torch<=1.2.0\n",
     "!pip install torchtext==0.4\n",
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1\n",
     "%matplotlib inline"
    ]

--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install json-tricks "
    ]

--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install json-tricks "
    ]

--- a/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
+++ b/examples/Arangopipe_with_TensorFlow_Beginner_Guide.ipynb
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install json-tricks "
    ]

--- a/examples/Data_Summaries.ipynb
+++ b/examples/Data_Summaries.ipynb
@@ -1,12 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -24,17 +16,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",
     "!pip install dtreeviz"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -45,15 +37,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "import pandas as pd\n",
     "data_url = \"https://raw.githubusercontent.com/arangoml/arangopipe/arangopipe_examples/examples/data/cal_housing.csv\"\n",
     "df = pd.read_csv(data_url, error_bad_lines=False)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -64,30 +56,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "df.describe()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "df.dtypes"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "df.hist()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -100,7 +92,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from arangopipe.arangopipe_storage.arangopipe_api import ArangoPipe\n",
     "from arangopipe.arangopipe_storage.arangopipe_admin_api import ArangoPipeAdmin\n",
@@ -111,13 +105,13 @@
     "drive.mount('/content/drive')\n",
     "fp = '/content/drive/My Drive/saved_arangopipe_config.yaml'\n",
     "conn_params = mdb_config.create_config(fp)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "mdb_config = mdb_config.create_connection_config(conn_params)\n",
     "admin = ArangoPipeAdmin(reuse_connection = True, config = mdb_config)\n",
@@ -128,36 +122,40 @@
     "\n",
     "model_info = {\"name\": \"Data Summaries for Housing Dataset\",  \"task\": \"Exploratory Data Analysis\"}\n",
     "model_reg = ap.register_model(model_info, project = \"Housing_Price_Estimation_Project\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "lasso_model = ap.lookup_model(\"Lasso Model for Housing Dataset\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "lasso_model"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "source": [
-    ""
-   ],
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/Data_Summaries.ipynb
+++ b/examples/Data_Summaries.ipynb
@@ -11,6 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    " <a href=\"https://colab.research.google.com/github/arangoml/arangopipe/blob/master/examples/Data_Summaries.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Install Prequisites"
    ]
   },
@@ -21,7 +28,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",
@@ -87,7 +94,7 @@
    "source": [
     "## Store Results in Arangopipe Database Used For Model Tracking\n",
     "\n",
-    "NOTE: You need to run this notebook after you have run the notebook Arangopipe_Feature_Examples.ipynb. We will be using the same database to store the modeling activity. Unused Arangopipe managed service instances may have been recycled. So if it has been a while (more than two weeks) since you have run the Arangopipe_Feature_Examples notebook, please run that notebook prior to running this one."
+    "**NOTE: You need to run this notebook after you have run the notebook Arangopipe_Feature_Examples.ipynb. We will be using the same database to store the modeling activity. Unused Arangopipe managed service instances may have been recycled. So if it has been a while (more than two weeks) since you have run the Arangopipe_Feature_Examples notebook, please run that notebook prior to running this one."
    ]
   },
   {
@@ -125,6 +132,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linking Models\n",
+    "We will link the model created in this notebook to the model created in  the notebook Arangopipe_Feature_Examples.ipynb. To do so, we need to do the following:\n",
+    "1. Lookup the model we want to link to and obtain its identifier\n",
+    "2. Call the link entities API with the model identifier created in this notebook as the source and the model identifier obtained from the lookup in the previous step as the destination\n",
+    "\n",
+    "The link entities API creates an attribute called \"related_models\" in the source node. We can verify the successfull linking by introspecting the model object to verify that the attribute capturing the related model is created."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -139,7 +158,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lasso_model"
+    "model_reg['_id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lasso_model['_id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ap.link_entities(model_reg['_id'], lasso_model['_id'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ap.lookup_model(\"Data Summaries for Housing Dataset\")"
    ]
   },
   {

--- a/examples/Data_Summaries.ipynb
+++ b/examples/Data_Summaries.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle\n",
     "!pip install seaborn\n",

--- a/examples/Data_Summaries.ipynb
+++ b/examples/Data_Summaries.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "## Store Results in Arangopipe Database Used For Model Tracking\n",
     "\n",
-    "**NOTE: You need to run this notebook after you have run the notebook Arangopipe_Feature_Examples.ipynb. We will be using the same database to store the modeling activity. Unused Arangopipe managed service instances may have been recycled. So if it has been a while (more than two weeks) since you have run the Arangopipe_Feature_Examples notebook, please run that notebook prior to running this one."
+    "**NOTE: You need to run this notebook after you have run the notebook Arangopipe_Feature_Examples.ipynb**. We will be using the same database to store the modeling activity. Unused Arangopipe managed service instances may have been recycled. So if it has been a while (more than two weeks) since you have run the Arangopipe_Feature_Examples notebook, please run that notebook prior to running this one."
    ]
   },
   {

--- a/examples/Reuse_Old_Arangopipe_Connection.ipynb
+++ b/examples/Reuse_Old_Arangopipe_Connection.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.1\n",
+    "!pip install arangopipe==0.0.6.9.3\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Reuse_Old_Arangopipe_Connection.ipynb
+++ b/examples/Reuse_Old_Arangopipe_Connection.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.8.6\n",
+    "!pip install arangopipe==0.0.6.9.0\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]

--- a/examples/Reuse_Old_Arangopipe_Connection.ipynb
+++ b/examples/Reuse_Old_Arangopipe_Connection.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install python-arango\n",
-    "!pip install arangopipe==0.0.6.9.0\n",
+    "!pip install arangopipe==0.0.6.9.1\n",
     "!pip install pandas PyYAML==5.1.1 sklearn2\n",
     "!pip install jsonpickle"
    ]


### PR DESCRIPTION
This PR implements the link entities API and contains all changes and comments from PR#101. The link entities API has the following signature:
link_entities(source_entity, target_entity)
Executing the API results in adding an attribute called related<entities> in the source vertex. If the entity is a model, a "related_model" attribute that contains the target entity is added. An example is provided in the notebook called DataSummaries.ipynb in the examples directory.
